### PR TITLE
fix sardine checkout refreshing when switching tabs + release 2.8.9

### DIFF
--- a/examples/next/CHANGELOG.md
+++ b/examples/next/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @0xsequence/kit-example-next
 
+## 0.6.9
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @0xsequence/kit-checkout@2.8.9
+  - @0xsequence/kit-connectors@2.8.9
+  - @0xsequence/kit@2.8.9
+  - @0xsequence/kit-wallet@2.8.9
+
 ## 0.6.8
 
 ### Patch Changes

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/kit-example-next",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "private": true,
   "scripts": {
     "dev": "next dev -p 4444",

--- a/examples/react/CHANGELOG.md
+++ b/examples/react/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @0xsequence/kit-example-react
 
+## 0.7.9
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @0xsequence/kit-checkout@2.8.9
+  - @0xsequence/kit-connectors@2.8.9
+  - @0xsequence/kit@2.8.9
+  - @0xsequence/kit-wallet@2.8.9
+
 ## 0.7.8
 
 ### Patch Changes

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/kit-example-react",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "private": true,
   "homepage": "kit",
   "type": "module",

--- a/packages/checkout/CHANGELOG.md
+++ b/packages/checkout/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @0xsequence/kit-connectors
 
+## 2.8.9
+
+### Patch Changes
+
+- Fix issue with NFT checkout that causes the flow to refresh upon switching tabs
+
+- Updated dependencies []:
+  - @0xsequence/kit@2.8.9
+
 ## 2.8.8
 
 ### Patch Changes

--- a/packages/checkout/package.json
+++ b/packages/checkout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/kit-checkout",
-  "version": "2.8.8",
+  "version": "2.8.9",
   "description": "Checkout UI for Sequence Kit",
   "repository": "https://github.com/0xsequence/kit/tree/master/packages/checkout",
   "author": "Horizon Blockchain Games",

--- a/packages/checkout/src/hooks/useSardineClientToken.ts
+++ b/packages/checkout/src/hooks/useSardineClientToken.ts
@@ -13,5 +13,6 @@ export const useSardineClientToken = (args: FetchSardineClientTokenArgs, disable
     retry: false,
     staleTime: 0,
     enabled: !disabled,
+    refetchOnWindowFocus: false,
   })
 }

--- a/packages/connectors/CHANGELOG.md
+++ b/packages/connectors/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @0xsequence/kit-connectors
 
+## 2.8.9
+
+### Patch Changes
+
+- Fix issue with NFT checkout that causes the flow to refresh upon switching tabs
+
+- Updated dependencies []:
+  - @0xsequence/kit@2.8.9
+
 ## 2.8.8
 
 ### Patch Changes

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/kit-connectors",
-  "version": "2.8.8",
+  "version": "2.8.9",
   "description": "Wallets for Sequence Kit",
   "repository": "https://github.com/0xsequence/kit/tree/master/packages/connectors",
   "author": "Horizon Blockchain Games",

--- a/packages/kit/CHANGELOG.md
+++ b/packages/kit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/kit
 
+## 2.8.9
+
+### Patch Changes
+
+- Fix issue with NFT checkout that causes the flow to refresh upon switching tabs
+
 ## 2.8.8
 
 ### Patch Changes

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/kit",
-  "version": "2.8.8",
+  "version": "2.8.9",
   "description": "Core package for Sequence Kit",
   "keywords": [
     "sequence",

--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @0xsequence/kit-wallet
 
+## 2.8.9
+
+### Patch Changes
+
+- Fix issue with NFT checkout that causes the flow to refresh upon switching tabs
+
+- Updated dependencies []:
+  - @0xsequence/kit@2.8.9
+
 ## 2.8.8
 
 ### Patch Changes

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/kit-wallet",
-  "version": "2.8.8",
+  "version": "2.8.9",
   "description": "Wallet UI for Sequence Kit",
   "repository": "https://github.com/0xsequence/kit/tree/master/packages/wallet",
   "author": "Horizon Blockchain Games",


### PR DESCRIPTION
Fix issue causing the NFT checkout to refresh when switching tabs.