### PR TITLE
Export connect wallet content to preview on Builder

### DIFF
--- a/packages/kit/src/components/Connect/ConnectWalletContent.tsx
+++ b/packages/kit/src/components/Connect/ConnectWalletContent.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { Box, Text } from '@0xsequence/design-system'
 
 import { FormattedEmailConflictInfo } from '../../hooks/useWaasEmailConflict'

--- a/packages/kit/src/components/Connect/ConnectWalletContent.tsx
+++ b/packages/kit/src/components/Connect/ConnectWalletContent.tsx
@@ -1,0 +1,32 @@
+import { Box, Text } from '@0xsequence/design-system'
+
+import { FormattedEmailConflictInfo } from '../../hooks/useWaasEmailConflict'
+import { KitConnectProviderProps } from '../KitProvider/KitProvider'
+
+import { Connect } from './Connect'
+
+interface ConnectWalletContent extends KitConnectProviderProps {
+  emailConflictInfo?: FormattedEmailConflictInfo | null
+  onClose: () => void
+}
+
+export const ConnectWalletContent = (props: ConnectWalletContent) => {
+  const { emailConflictInfo, config } = props
+  const projectName = config?.signIn?.projectName
+  return (
+    <Box padding="4">
+      <Box
+        justifyContent="center"
+        color="text100"
+        alignItems="center"
+        fontWeight="medium"
+        style={{
+          marginTop: '4px'
+        }}
+      >
+        <Text>Sign in {projectName ? `to ${projectName}` : ''}</Text>
+      </Box>
+      <Connect emailConflictInfo={emailConflictInfo} {...props} />
+    </Box>
+  )
+}

--- a/packages/kit/src/components/Connect/index.ts
+++ b/packages/kit/src/components/Connect/index.ts
@@ -1,1 +1,1 @@
-export { Connect } from './Connect'
+export { ConnectWalletContent } from './ConnectWalletContent'

--- a/packages/kit/src/components/KitProvider/KitProvider.tsx
+++ b/packages/kit/src/components/KitProvider/KitProvider.tsx
@@ -22,7 +22,7 @@ import { useWaasConfirmationHandler } from '../../hooks/useWaasConfirmationHandl
 import { useEmailConflict } from '../../hooks/useWaasEmailConflict'
 import { ExtendedConnector, DisplayedAsset, EthAuthSettings, KitConfig, Theme, ModalPosition } from '../../types'
 import { getModalPositionCss } from '../../utils/styling'
-import { Connect } from '../Connect'
+import { ConnectWalletContent } from '../Connect'
 import { NetworkBadge } from '../NetworkBadge'
 import { PageHeading } from '../PageHeading'
 import { PoweredBySequence } from '../SequenceLogo'
@@ -48,7 +48,6 @@ export const KitProvider = (props: KitConnectProviderProps) => {
 
   const { expiry = DEFAULT_SESSION_EXPIRATION, app = defaultAppName, origin, nonce } = ethAuth
 
-  const { projectName } = signIn
   const [openConnectModal, setOpenConnectModal] = useState<boolean>(false)
   const [theme, setTheme] = useState<Exclude<Theme, undefined>>(defaultTheme || 'dark')
   const [modalPosition, setModalPosition] = useState<ModalPosition>(position)
@@ -158,26 +157,11 @@ export const KitProvider = (props: KitConnectProviderProps) => {
                           }}
                           onClose={() => setOpenConnectModal(false)}
                         >
-                          <Box padding="4">
-                            <Box
-                              justifyContent="center"
-                              color="text100"
-                              alignItems="center"
-                              fontWeight="medium"
-                              style={{
-                                marginTop: '4px'
-                              }}
-                            >
-                              <Text>Sign in {projectName ? `to ${projectName}` : ''}</Text>
-                            </Box>
-                            <Connect
-                              onClose={() => {
-                                setOpenConnectModal(false)
-                              }}
-                              {...props}
-                              emailConflictInfo={emailConflictInfo}
-                            />
-                          </Box>
+                          <ConnectWalletContent
+                            onClose={() => setOpenConnectModal(false)}
+                            emailConflictInfo={emailConflictInfo}
+                            {...props}
+                          />
                         </Modal>
                       )}
 

--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -1,6 +1,9 @@
 // Provider
 export { KitProvider } from './components/KitProvider'
 
+// Components
+export { ConnectWalletContent } from './components/Connect'
+
 // Types
 export type {
   Wallet,


### PR DESCRIPTION
I exported the content here because we want to preview how the wallet will look on the Builder side without opening a modal. This way, it will be very simple for us.

Ticket -> https://github.com/0xsequence/issue-tracker/issues/3081