### PR TITLE
Re export the design system styles.css from kit to reduce extra peer dependency on integrators

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ View the [demo](https://0xsequence.github.io/kit)! 👀
 To install this package:
 
 ```bash
-npm install @0xsequence/kit wagmi ethers@6.13.0 viem 0xsequence @tanstack/react-query @0xsequence/design-system
+npm install @0xsequence/kit wagmi ethers@6.13.0 viem 0xsequence @tanstack/react-query
 # or
-pnpm install @0xsequence/kit wagmi ethers@6.13.0 viem 0xsequence @tanstack/react-query @0xsequence/design-system
+pnpm install @0xsequence/kit wagmi ethers@6.13.0 viem 0xsequence @tanstack/react-query
 # or
-yarn add @0xsequence/kit wagmi ethers@6.13.0 viem 0xsequence @tanstack/react-query @0xsequence/design-system
+yarn add @0xsequence/kit wagmi ethers@6.13.0 viem 0xsequence @tanstack/react-query
 ```
 
 ### Setting up the Library
@@ -136,7 +136,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { createConfig, http, WagmiProvider } from 'wagmi'
 import { mainnet, polygon, Chain } from 'wagmi/chains'
 
-import '@0xsequence/design-system/styles.css'
+import '@0xsequence/kit/styles.css'
 
 const projectAccessKey = '<your-project-access-key>'
 

--- a/examples/next/src/app/layout.tsx
+++ b/examples/next/src/app/layout.tsx
@@ -5,7 +5,7 @@ import { headers } from 'next/headers'
 import { cookieToInitialState } from 'wagmi'
 
 import './globals.css'
-import '@0xsequence/design-system/styles.css'
+import '@0xsequence/kit/styles.css'
 
 import { config } from '../config'
 

--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -1,4 +1,4 @@
-import '@0xsequence/design-system/styles.css'
+import '@0xsequence/kit/styles.css'
 
 import { ThemeProvider } from '@0xsequence/design-system'
 import { SequenceKit } from '@0xsequence/kit'

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "dev:react": "pnpm --filter @0xsequence/kit-example-react dev",
     "serve:react": "pnpm --filter @0xsequence/kit-example-react serve",
     "build:react": "pnpm --filter @0xsequence/kit-example-react build",
+    "dev:react-boilerplate": "pnpm --filter @0xsequence/kit-example-react-boilerplate dev",
+    "serve:react-boilerplate": "pnpm --filter @0xsequence/kit-example-react-boilerplate serve",
+    "build:react-boilerplate": "pnpm --filter @0xsequence/kit-example-react-boilerplate build",
     "dev:next": "pnpm --filter @0xsequence/kit-example-next dev",
     "serve:next": "pnpm --filter @0xsequence/kit-example-next start",
     "build:next": "pnpm --filter @0xsequence/kit-example-next build"

--- a/packages/kit/README.md
+++ b/packages/kit/README.md
@@ -21,11 +21,11 @@ View the [demo](https://0xsequence.github.io/kit)! 👀
 To install this package:
 
 ```bash
-npm install @0xsequence/kit wagmi ethers@6.13.0 viem 0xsequence @tanstack/react-query @0xsequence/design-system
+npm install @0xsequence/kit wagmi ethers@6.13.0 viem 0xsequence @tanstack/react-query
 # or
-pnpm install @0xsequence/kit wagmi ethers@6.13.0 viem 0xsequence @tanstack/react-query @0xsequence/design-system
+pnpm install @0xsequence/kit wagmi ethers@6.13.0 viem 0xsequence @tanstack/react-query
 # or
-yarn add @0xsequence/kit wagmi ethers@6.13.0 viem 0xsequence @tanstack/react-query @0xsequence/design-system
+yarn add @0xsequence/kit wagmi ethers@6.13.0 viem 0xsequence @tanstack/react-query
 ```
 
 ### Setting up the Library
@@ -135,7 +135,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { createConfig, http, WagmiProvider } from 'wagmi'
 import { mainnet, polygon, Chain } from 'wagmi/chains'
 
-import '@0xsequence/design-system/styles.css'
+import '@0xsequence/kit/styles.css'
 
 const projectAccessKey = 'xyz'
 

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -19,7 +19,8 @@
       "require": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
       "default": "./dist/esm/index.js"
-    }
+    },
+    "./styles.css": "./node_modules/@0xsequence/design-system/dist/style.css"
   },
   "files": [
     "src",
@@ -39,6 +40,7 @@
     "@0xsequence/api": "^2.0.9",
     "@0xsequence/auth": "^2.0.9",
     "@0xsequence/core": "^2.0.9",
+    "@0xsequence/design-system": "^1.7.8",
     "@0xsequence/ethauth": "^1.0.0",
     "@0xsequence/indexer": "^2.0.9",
     "@0xsequence/metadata": "^2.0.9",
@@ -51,7 +53,6 @@
   },
   "peerDependencies": {
     "0xsequence": ">= 2.0.9",
-    "@0xsequence/design-system": ">=1.7.8",
     "@react-oauth/google": ">= 0.11.1",
     "@tanstack/react-query": ">= 5.0.0",
     "ethers": ">= 6.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,7 +297,7 @@ importers:
         specifier: ^2.0.9
         version: 2.0.9(ethers@6.13.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@0xsequence/design-system':
-        specifier: '>=1.7.8'
+        specifier: ^1.7.8
         version: 1.7.8(@types/react-dom@18.3.0)(@types/react@18.3.8)(framer-motion@8.5.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@0xsequence/ethauth':
         specifier: ^1.0.0


### PR DESCRIPTION
Currently we require integrators to add @0xsequence/design-system as a peer dependency so that they may import @0xsequence/design-system/styles.css into their project and allow their unique bundler setup to take over including of the css file in their project.

But if we add design-system as a regular dependency of kit we can rexport the styles.css to make this simpler.

```
  "exports": {
    ".": {
      "types": "./dist/types/index.d.ts",
      "require": "./dist/cjs/index.js",
      "import": "./dist/esm/index.js",
      "default": "./dist/esm/index.js"
    },
    "./styles.css": "./node_modules/@0xsequence/design-system/dist/style.css"
  },
```

before:

```ts
import from '@0xsequence/design-system/styles.css'
```

after:

```ts
import from '@0sequence/kit/styles.css`
```

Since each project will already have the kit package as a dependency this will make things simpler to setup and it also sets ground work for future design-system changes where each project will be in charge of preparing their own pruned css file based on which atomic classes (rules and values) they used. This is nice because we don't have to ship the entirety of our css.