### PR TITLE
Added cryptoCurrencyList and fiatAmount Query Params for Transak Modal

### DIFF
--- a/packages/checkout/src/contexts/AddFundsModal.ts
+++ b/packages/checkout/src/contexts/AddFundsModal.ts
@@ -4,9 +4,11 @@ import { createGenericContext } from './genericContext'
 
 export interface AddFundsSettings {
   walletAddress: string | Hex
+  fiatAmount?: string
   fiatCurrency?: string
   defaultFiatAmount?: string
   defaultCryptoCurrency?: string
+  cryptoCurrencyList?: string
   networks?: string
   onClose?: () => void
 }

--- a/packages/checkout/src/utils/transak.ts
+++ b/packages/checkout/src/utils/transak.ts
@@ -13,10 +13,12 @@ export const getTransakLink = (addFundsSettings: AddFundsSettings) => {
     apiKey: TRANSAK_API_KEY,
     referrerDomain: window.location.origin,
     walletAddress: addFundsSettings.walletAddress,
+    fiatAmount: addFundsSettings?.fiatAmount,
     fiatCurrency: addFundsSettings?.fiatCurrency,
     disableWalletAddressForm: 'true',
     defaultFiatAmount: addFundsSettings?.defaultFiatAmount || '50',
     defaultCryptoCurrency: addFundsSettings?.defaultCryptoCurrency || 'USDC',
+    cryptoCurrencyList: addFundsSettings?.cryptoCurrencyList,
     networks: addFundsSettings?.networks || defaultNetworks
   }
 


### PR DESCRIPTION
I Exposed more Transak variables. Quick change requested by a developer. This allows developers to specify Fiat amount and currencies, and restrict users from changing these values.