### PR TITLE
Sequence pay fixes

### DIFF
--- a/examples/react/src/components/Connected.tsx
+++ b/examples/react/src/components/Connected.tsx
@@ -274,7 +274,7 @@ export const Connected = () => {
         }
       ],
       title: 'Swap and Pay',
-      description: 'Customizable swap and pay flow. This text is customizable.'
+      description: 'Select a token in your wallet to swap to 0.2 USDC.'
     }
 
     openSwapModal(swapModalSettings)
@@ -461,8 +461,8 @@ export const Connected = () => {
               </>
             )}
             <CardButton
-              title="Customizable Swapping with Sequence Pay"
-              description="Swap between currencies and send transactions"
+              title="Swap with Sequence Pay"
+              description="Seamlessly swap eligible currencies in your wallet to a target currency"
               onClick={onClickSwap}
             />
 

--- a/packages/checkout/src/views/PaymentSelection/PayWithCrypto/index.tsx
+++ b/packages/checkout/src/views/PaymentSelection/PayWithCrypto/index.tsx
@@ -1,5 +1,5 @@
 import { Box, Text, Scroll, Spinner } from '@0xsequence/design-system'
-import { useBalances, useContractInfo, useSwapPrices, compareAddress, NATIVE_TOKEN_ADDRESS_0X } from '@0xsequence/kit'
+import { useBalances, useContractInfo, useSwapPrices, compareAddress } from '@0xsequence/kit'
 import { findSupportedNetwork } from '@0xsequence/network'
 import { useState, useEffect, Fragment, SetStateAction } from 'react'
 import { formatUnits, zeroAddress } from 'viem'
@@ -43,9 +43,7 @@ export const PayWithCrypto = ({
 
   const { data: currencyInfoData, isLoading: isLoadingCurrencyInfo } = useContractInfo(chainId, currencyAddress)
 
-  const buyCurrencyAddress = compareAddress(settings?.currencyAddress, zeroAddress)
-    ? NATIVE_TOKEN_ADDRESS_0X
-    : settings?.currencyAddress
+  const buyCurrencyAddress = settings?.currencyAddress
 
   const { data: swapPrices = [], isLoading: swapPricesIsLoading } = useSwapPrices(
     {

--- a/packages/checkout/src/views/PaymentSelection/index.tsx
+++ b/packages/checkout/src/views/PaymentSelection/index.tsx
@@ -7,8 +7,7 @@ import {
   compareAddress,
   TRANSACTION_CONFIRMATIONS_DEFAULT,
   sendTransactions,
-  SwapPricesWithCurrencyInfo,
-  NATIVE_TOKEN_ADDRESS_0X
+  SwapPricesWithCurrencyInfo
 } from '@0xsequence/kit'
 import { findSupportedNetwork } from '@0xsequence/network'
 import { useState, useEffect } from 'react'
@@ -101,7 +100,8 @@ export const PaymentSelectionContent = () => {
 
   const { data: currencyInfoData, isLoading: isLoadingCurrencyInfo } = useContractInfo(chainId, currencyAddress)
 
-  const buyCurrencyAddress = compareAddress(currencyAddress, zeroAddress) ? NATIVE_TOKEN_ADDRESS_0X : currencyAddress
+  const buyCurrencyAddress = currencyAddress
+  const sellCurrencyAddress = selectedCurrency || ''
 
   const { data: swapPrices = [], isLoading: swapPricesIsLoading } = useSwapPrices(
     {
@@ -114,11 +114,7 @@ export const PaymentSelectionContent = () => {
     { disabled: !enableSwapPayments }
   )
 
-  const disableSwapQuote = !selectedCurrency || compareAddress(currencyAddress, selectedCurrency || '')
-
-  const swapQuotesSellCurrency = compareAddress(currencyAddress || '', zeroAddress)
-    ? NATIVE_TOKEN_ADDRESS_0X
-    : selectedCurrency || ''
+  const disableSwapQuote = !selectedCurrency || compareAddress(selectedCurrency, buyCurrencyAddress)
 
   const { data: swapQuote, isLoading: isLoadingSwapQuote } = useSwapQuote(
     {
@@ -126,11 +122,11 @@ export const PaymentSelectionContent = () => {
       buyCurrencyAddress: currencyAddress,
       buyAmount: price,
       chainId: chainId,
-      sellCurrencyAddress: swapQuotesSellCurrency,
+      sellCurrencyAddress,
       includeApprove: true
     },
     {
-      disabled: !selectedCurrency
+      disabled: disableSwapQuote
     }
   )
 
@@ -248,7 +244,7 @@ export const PaymentSelectionContent = () => {
         args: [targetContractAddress, price]
       })
 
-      const isSwapNativeToken = compareAddress(NATIVE_TOKEN_ADDRESS_0X, swapPrice.price.currencyAddress)
+      const isSwapNativeToken = compareAddress(zeroAddress, swapPrice.price.currencyAddress)
 
       const transactions = [
         // Swap quote optional approve step

--- a/packages/checkout/src/views/Swap/index.tsx
+++ b/packages/checkout/src/views/Swap/index.tsx
@@ -16,7 +16,7 @@ export const Swap = () => {
     currencyAddress,
     currencyAmount,
     chainId,
-    disableMainCurrency = false,
+    disableMainCurrency = true,
     description,
     postSwapTransactions,
     blockConfirmations,

--- a/packages/checkout/src/views/Swap/index.tsx
+++ b/packages/checkout/src/views/Swap/index.tsx
@@ -1,14 +1,6 @@
 import { useState } from 'react'
 import { Box, Button, Spinner, Text } from '@0xsequence/design-system'
-import {
-  compareAddress,
-  formatDisplay,
-  useContractInfo,
-  useSwapPrices,
-  useSwapQuote,
-  NATIVE_TOKEN_ADDRESS_0X,
-  sendTransactions
-} from '@0xsequence/kit'
+import { compareAddress, formatDisplay, useContractInfo, useSwapPrices, useSwapQuote, sendTransactions } from '@0xsequence/kit'
 import { findSupportedNetwork } from '@0xsequence/network'
 import { zeroAddress, formatUnits, Hex } from 'viem'
 import { useAccount, usePublicClient, useWalletClient } from 'wagmi'
@@ -37,7 +29,8 @@ export const Swap = () => {
   const publicClient = usePublicClient({ chainId })
   const { data: walletClient } = useWalletClient()
 
-  const buyCurrencyAddress = compareAddress(currencyAddress, zeroAddress) ? NATIVE_TOKEN_ADDRESS_0X : currencyAddress
+  const buyCurrencyAddress = currencyAddress
+  const sellCurrencyAddress = selectedCurrency || ''
 
   const { data: currencyInfoData, isLoading: isLoadingCurrencyInfo } = useContractInfo(chainId, currencyAddress)
 
@@ -52,7 +45,6 @@ export const Swap = () => {
     { disabled: false }
   )
 
-  const sellCurrency0x = compareAddress(selectedCurrency || '', zeroAddress) ? NATIVE_TOKEN_ADDRESS_0X : selectedCurrency
   const isNativeCurrency = compareAddress(currencyAddress, zeroAddress)
   const network = findSupportedNetwork(chainId)
 
@@ -61,17 +53,19 @@ export const Swap = () => {
   const mainCurrencySymbol = isNativeCurrency ? network?.nativeToken.symbol : currencyInfoData?.symbol
   const mainCurrencyDecimals = isNativeCurrency ? network?.nativeToken.decimals : currencyInfoData?.decimals
 
+  const disableSwapQuote = !selectedCurrency || compareAddress(selectedCurrency, buyCurrencyAddress)
+
   const { data: swapQuote, isLoading: isLoadingSwapQuote } = useSwapQuote(
     {
       userAddress: userAddress ?? '',
       buyCurrencyAddress: currencyAddress,
       buyAmount: currencyAmount,
       chainId: chainId,
-      sellCurrencyAddress: sellCurrency0x || '',
+      sellCurrencyAddress,
       includeApprove: true
     },
     {
-      disabled: !selectedCurrency
+      disabled: disableSwapQuote
     }
   )
 
@@ -90,7 +84,7 @@ export const Swap = () => {
 
     try {
       const swapPrice = swapPrices?.find(price => price.info?.address === selectedCurrency)
-      const isSwapNativeToken = compareAddress(NATIVE_TOKEN_ADDRESS_0X, swapPrice?.price.currencyAddress || '')
+      const isSwapNativeToken = compareAddress(zeroAddress, swapPrice?.price.currencyAddress || '')
 
       const getSwapTransactions = () => {
         if (isMainCurrencySelected || !swapQuote || !swapPrice) {
@@ -189,9 +183,7 @@ export const Swap = () => {
               />
             )}
             {swapPrices.map(swapPrice => {
-              const sellCurrencyAddress = compareAddress(swapPrice.info?.address || '', NATIVE_TOKEN_ADDRESS_0X)
-                ? zeroAddress
-                : swapPrice.info?.address || ''
+              const sellCurrencyAddress = swapPrice.info?.address || ''
 
               const formattedPrice = formatDisplay(formatUnits(BigInt(swapPrice.price.price), swapPrice.info?.decimals || 0))
 

--- a/packages/checkout/src/views/Swap/index.tsx
+++ b/packages/checkout/src/views/Swap/index.tsx
@@ -34,7 +34,7 @@ export const Swap = () => {
   const [isTxsPending, setIsTxsPending] = useState(false)
   const [isError, setIsError] = useState(false)
   const [selectedCurrency, setSelectedCurrency] = useState<string>()
-  const publicClient = usePublicClient()
+  const publicClient = usePublicClient({ chainId })
   const { data: walletClient } = useWalletClient()
 
   const buyCurrencyAddress = compareAddress(currencyAddress, zeroAddress) ? NATIVE_TOKEN_ADDRESS_0X : currencyAddress

--- a/packages/checkout/src/views/TransactionStatus/index.tsx
+++ b/packages/checkout/src/views/TransactionStatus/index.tsx
@@ -92,7 +92,9 @@ export const TransactionStatus = () => {
     noItemsToDisplay
   )
 
-  const publicClient = usePublicClient()
+  const publicClient = usePublicClient({
+    chainId
+  })
 
   const waitForTransaction = async (client: PublicClient, txnHash: string) => {
     try {


### PR DESCRIPTION
Fixes related to sequence pay:

1: Clearer details related to the Swap modal in the demo
2: in the swap modal, the main currency defaults to being hidden
3: Simplified management of the zero address with the swap API (0x uses a different addres for the native currency the 0x000..)
4: Fixed the public client to the desired chain id to avoir network switching issues 