### PR TITLE
network switching issues fix for swap modal

### DIFF
--- a/packages/checkout/src/views/Swap/index.tsx
+++ b/packages/checkout/src/views/Swap/index.tsx
@@ -117,6 +117,11 @@ export const Swap = () => {
         return swapTransactions
       }
 
+      const walletClientChainId = await walletClient.getChainId()
+      if (walletClientChainId !== chainId) {
+        await walletClient.switchChain({ id: chainId })
+      }
+
       const txHash = await sendTransactions({
         connector,
         walletClient,


### PR DESCRIPTION
Fixed issue when the selected network not corresponding to the TX chain caused an error.