### PR TITLE
immutable zkevm as part of default networks for transak

### DIFF
--- a/packages/checkout/src/utils/transak.ts
+++ b/packages/checkout/src/utils/transak.ts
@@ -3,7 +3,7 @@ import { AddFundsSettings } from '../contexts'
 export const TRANSAK_API_KEY = '5911d9ec-46b5-48fa-a755-d59a715ff0cf'
 
 export const getTransakLink = (addFundsSettings: AddFundsSettings) => {
-  const defaultNetworks = 'ethereum,mainnet,arbitrum,optimism,polygon,polygonzkevm,zksync,base,bnb,oasys,astar,avaxcchain'
+  const defaultNetworks = 'ethereum,mainnet,arbitrum,optimism,polygon,polygonzkevm,zksync,base,bnb,oasys,astar,avaxcchain,immutablezkevm'
 
   interface Options {
     [index: string]: string | undefined


### PR DESCRIPTION
Added immutable zkevm as part of the default networks for transak fiat onramp