### PR TITLE
Transferring ERC-1155 fix from inventory

### DIFF
--- a/packages/wallet/src/views/SendCollectible.tsx
+++ b/packages/wallet/src/views/SendCollectible.tsx
@@ -18,6 +18,7 @@ import { TokenBalance } from '@0xsequence/indexer'
 import { getNativeTokenInfoByChainId, useAnalyticsContext, ExtendedConnector, useCollectibleBalance } from '@0xsequence/kit'
 import { ethers } from 'ethers'
 import React, { useRef, useState, ChangeEvent, useEffect } from 'react'
+import { zeroAddress } from 'viem'
 import { useAccount, useChainId, useSwitchChain, useConfig, useSendTransaction } from 'wagmi'
 
 import { ERC_1155_ABI, ERC_721_ABI, HEADER_HEIGHT } from '../constants'
@@ -191,7 +192,7 @@ export const SendCollectible = ({ chainId, contractAddress, tokenId }: SendColle
               toAddress,
               [tokenId],
               [ethers.toQuantity(sendAmount)],
-              []
+              zeroAddress
             ]) as `0x${string}`,
             gas: null
           },

--- a/packages/wallet/src/views/SendCollectible.tsx
+++ b/packages/wallet/src/views/SendCollectible.tsx
@@ -192,7 +192,7 @@ export const SendCollectible = ({ chainId, contractAddress, tokenId }: SendColle
               toAddress,
               [tokenId],
               [ethers.toQuantity(sendAmount)],
-              zeroAddress
+              new Uint8Array()
             ]) as `0x${string}`,
             gas: null
           },


### PR DESCRIPTION
Fix issues which prevents ERC-1155 to be transferred from the inventory.