### PR TITLE
native token option faster loading in checkout

### DIFF
--- a/packages/checkout/src/views/PaymentSelection/index.tsx
+++ b/packages/checkout/src/views/PaymentSelection/index.tsx
@@ -88,7 +88,7 @@ export const PaymentSelectionContent = () => {
     address: currencyAddress as Hex,
     args: [userAddress, targetContractAddress],
     query: {
-      enabled: !!userAddress
+      enabled: !!userAddress && !isNativeToken
     }
   })
 
@@ -132,7 +132,7 @@ export const PaymentSelectionContent = () => {
     }
   )
 
-  const isLoading = allowanceIsLoading || currencyBalanceIsLoading || isLoadingCurrencyInfo
+  const isLoading = (allowanceIsLoading && !isNativeToken) || currencyBalanceIsLoading || isLoadingCurrencyInfo
 
   const isApproved: boolean = (allowanceData as bigint) >= BigInt(price) || isNativeToken
 


### PR DESCRIPTION
Faster native token option loading in Sequence Checkout when it is the target contract's currency.

![image](https://github.com/user-attachments/assets/ff3262b9-da29-41ca-b9e7-592552b49545)
