### PR TITLE
export useNavigation for instant custom inventory views

### DIFF
--- a/examples/react/src/components/Connected.tsx
+++ b/examples/react/src/components/Connected.tsx
@@ -10,12 +10,13 @@ import {
 import { useCheckoutModal, useAddFundsModal, useERC1155SaleContractPaymentModal, useSwapModal } from '@0xsequence/kit-checkout'
 import type { SwapModalSettings } from '@0xsequence/kit-checkout'
 import { CardButton, Header } from '@0xsequence/kit-example-shared-components'
-import { useOpenWalletModal } from '@0xsequence/kit-wallet'
+import { useOpenWalletModal, useWalletNavigation } from '@0xsequence/kit-wallet'
 import { allNetworks, ChainId } from '@0xsequence/network'
 import { ethers } from 'ethers'
 import { AnimatePresence } from 'framer-motion'
 import React, { ComponentProps, useEffect } from 'react'
 import { formatUnits, parseUnits } from 'viem'
+import { arbitrumSepolia } from 'viem/chains'
 import {
   useAccount,
   useChainId,
@@ -485,6 +486,8 @@ export const Connected = () => {
     setFeeOptionBalances([])
   }, [chainId])
 
+  const { setNavigation } = useWalletNavigation()
+
   return (
     <>
       <Header />
@@ -505,7 +508,22 @@ export const Connected = () => {
               description="Connect a Sequence wallet to view, swap, send, and receive collections"
               onClick={() => setOpenWalletModal(true)}
             />
-
+            <CardButton
+              title="Inventory for Aviator on Arbitrum Sepolia"
+              description="Connect a Sequence wallet to view, swap, send, and receive collections"
+              onClick={() => {
+                setOpenWalletModal(true)
+                setTimeout(() => {
+                  setNavigation({
+                    location: 'collection-details',
+                    params: {
+                      contractAddress: '0xdbac91902dce61d231154bbcbb16227dca31141c',
+                      chainId: arbitrumSepolia.id
+                    }
+                  })
+                }, 0)
+              }}
+            />
             {(sponsoredContractAddresses[chainId] || networkForCurrentChainId.testnet) && (
               <CardButton
                 title="Send sponsored transaction"

--- a/packages/wallet/src/index.ts
+++ b/packages/wallet/src/index.ts
@@ -3,3 +3,4 @@ export { KitWalletProvider } from './shared/KitWalletProvider'
 
 // Hooks
 export { useOpenWalletModal } from './hooks/useOpenWalletModal'
+export { useNavigation as useWalletNavigation} from './hooks/useNavigation'

--- a/packages/wallet/src/shared/KitWalletProvider/index.tsx
+++ b/packages/wallet/src/shared/KitWalletProvider/index.tsx
@@ -38,7 +38,7 @@ export const KitWalletContent = ({ children }: KitWalletProviderProps) => {
   // Navigation Context
   const [history, setHistory] = useState<History>([])
   const [isBackButtonEnabled, setIsBackButtonEnabled] = useState(true)
-  const navigation = history.length > 0 ? history[history.length - 1] : DEFAULT_LOCATION
+  const navigation = history.length > 0 ? history[history.length - 1] : DEFAULT_LOCATION;
 
   const displayScrollbar =
     navigation.location === 'home' ||


### PR DESCRIPTION
There's a good/easy use-case for a game that wants to show its users the assets specific to the game they're playing, rather than everything they own.
By exposing useNavigation as useWalletNavigation, we can have this functionality, and more.

The current implementation is a tiny bit hacky (it probably requests the inventory for the whole wallet first, before requesting the more specific inventory (after a timeout of 0).

I don't love it. It's not nice code to show/share:
```
setOpenWalletModal(true)
setTimeout(() => {
  setNavigation({
    location: 'collection-details',
    params: {
      contractAddress: '0xdbac91902dce61d231154bbcbb16227dca31141c',
      chainId: arbitrumSepolia.id
    }
  })
}, 0)
```

Ideally it would look like this:
```
setOpenWalletModal({
    location: 'collection-details',
    params: {
      contractAddress: '0xdbac91902dce61d231154bbcbb16227dca31141c',
      chainId: arbitrumSepolia.id
    }
  })
```
setOpenWalletModal would still take true/false as an argument, with the current default behaviour

Thoughts?
