### PR TITLE
Improved display of Swap Options in checkout modal

### DIFF
--- a/packages/checkout/src/views/PaymentSelection/PayWithCrypto/CryptoOption.tsx
+++ b/packages/checkout/src/views/PaymentSelection/PayWithCrypto/CryptoOption.tsx
@@ -55,7 +55,8 @@ export const CryptoOption = ({
             whiteSpace="nowrap"
             ellipsis
             style={{
-              overflow: 'hidden'
+              overflow: 'hidden',
+              maxWidth: '220px'
             }}
           >
             {currencyName}


### PR DESCRIPTION
Improved display of Swap Options in checkout modal by removing the double scrollbar in favor of show more button,

https://www.loom.com/share/03e14e95fb194ac8a39f8096620266df?sid=9ab2858d-5d3a-40c9-b608-70c3edc9666c