### PR TITLE
fixed coin images overflowing

### DIFF
--- a/packages/wallet/src/views/Home/components/AssetSummary/CoinTile/CoinTileContent.tsx
+++ b/packages/wallet/src/views/Home/components/AssetSummary/CoinTile/CoinTileContent.tsx
@@ -42,7 +42,6 @@ export const CoinTileContent = ({
       <Box>
         <Box flexDirection="row" gap="1" justifyContent="flex-start" alignItems="center">
           <Text
-            fontSize="medium"
             fontWeight="bold"
             whiteSpace="nowrap"
             color="text100"

--- a/packages/wallet/src/views/Home/components/AssetSummary/CoinTile/CoinTileContent.tsx
+++ b/packages/wallet/src/views/Home/components/AssetSummary/CoinTile/CoinTileContent.tsx
@@ -34,16 +34,15 @@ export const CoinTileContent = ({
       borderRadius="md"
       padding="4"
       flexDirection="column"
-      justifyContent="center"
+      justifyContent="space-between"
       alignItems="flex-start"
       gap="1"
     >
-      <Box marginBottom="1">
-        <TokenImage src={logoUrl} symbol={symbol} size="xl" />
-      </Box>
-      <Box marginBottom="3">
+      <TokenImage src={logoUrl} symbol={symbol} size="lg" />
+      <Box>
         <Box flexDirection="row" gap="1" justifyContent="flex-start" alignItems="center">
           <Text
+            fontSize="medium"
             fontWeight="bold"
             whiteSpace="nowrap"
             color="text100"


### PR DESCRIPTION
Fixed issue that of content of coin tile overflowing which caused issue with Eden online's marketplace.

![image](https://github.com/user-attachments/assets/d423fe1c-5913-454a-b697-a1f80bae9902)
